### PR TITLE
Fix(articles): Correct author payload for article creation

### DIFF
--- a/src/api/articles.ts
+++ b/src/api/articles.ts
@@ -13,3 +13,27 @@ export const getArticleById = async (id: string): Promise<Article> => {
   const response = await apiClient.get(`/articles/${id}`);
   return response.data;
 };
+
+// Data type for creating an article
+export interface CreateArticleData {
+  title: string;
+  content: string;
+  authorId: string;
+  authorName:string;
+  imageUrl?: string;
+}
+
+// Create a new article
+export const createArticle = async (data: CreateArticleData) => {
+  const payload = {
+    title: data.title,
+    content: data.content,
+    author: {
+      _id: data.authorId,
+      name: data.authorName,
+    },
+    imageUrl: data.imageUrl,
+  };
+  const response = await apiClient.post('/articles', payload);
+  return response.data;
+};

--- a/src/components/admin/CreateArticleForm.tsx
+++ b/src/components/admin/CreateArticleForm.tsx
@@ -9,7 +9,7 @@ import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
 import { useAdminRedirect } from '@/hooks/useAdminRedirect';
 import { useRouter } from 'next/navigation';
-import apiClient from '@/api/apiClient';
+import { createArticle } from '@/api/articles';
 import Link from 'next/link';
 import dynamic from 'next/dynamic'; // Import dynamic from Next.js
 import 'react-quill/dist/quill.snow.css';
@@ -48,24 +48,30 @@ const CreateArticleForm: React.FC = () => {
   });
 
   const onSubmit = async (data: ArticleFormInputs) => {
-    // Basic validation for content from quill
+    if (!user) {
+      setMessage({ type: 'error', text: 'You must be logged in to create an article.' });
+      return;
+    }
+
     if (content.length < 50) {
       setMessage({ type: 'error', text: 'Content must be at least 50 characters long.' });
       return;
     }
+
     setLoading(true);
     setMessage(null);
+
     try {
-      const response = await apiClient.post('/articles', {
+      await createArticle({
         title: data.title,
         content: content,
-        author: user?.name, // Use the logged-in user's name as the author
+        authorId: user.id,
+        authorName: user.name,
         imageUrl: data.imageUrl || undefined,
       });
-      setMessage({ type: 'success', text: response.data.message || 'Article created successfully!' });
+      setMessage({ type: 'success', text: 'Article created successfully!' });
       reset();
       setContent('');
-      // Optionally redirect after a brief delay
       setTimeout(() => router.push('/articles'), 2000);
     } catch (error: any) {
       console.error('Article creation error:', error);


### PR DESCRIPTION
The create-article page was resulting in an error because the author information was being sent in an incorrect format. The backend API expects an author object containing `_id` and `name`, but the frontend was only sending the author's name as a string.

This commit resolves the issue in the following way:
- Creating a new `createArticle` function in `src/api/articles.ts` to encapsulate the API call and ensure the payload is structured correctly.
- Updating the `CreateArticleForm` component to use this new function.
- Passing the author's ID and name from the authenticated user's state, mapped to the expected `{ _id, name }` format.
- Adding a check to prevent article creation if the user is not logged in.