### PR TITLE
This commit addresses two issues that were preventing the create-arti…

### DIFF
--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -27,10 +27,10 @@ interface AuthState {
 
 // Create the Zustand store
 const useAuthStore = create<AuthState>((set) => ({
-  token: typeof window !== 'undefined' ? localStorage.getItem('token') : null, // Initialize from localStorage on client side
-  user: typeof window !== 'undefined' ? JSON.parse(localStorage.getItem('user') || 'null') : null, // Initialize user from localStorage
-  isLoggedIn: typeof window !== 'undefined' ? !!localStorage.getItem('token') : false, // Derived from token existence
-  isLoading: true, // Set to true initially, will be false after checking localStorage
+  token: null,
+  user: null,
+  isLoggedIn: false,
+  isLoading: true,
   error: null,
 
   login: (token, user) => {


### PR DESCRIPTION
…cle page from functioning correctly.

First, it resolves a bug where creating an article would fail due to an incorrect payload format. The backend API expects the author to be an object with an `_id` and `name`, but the frontend was only sending the author's name. This is fixed by:
- Creating a new `createArticle` function in `src/api/articles.ts`.
- Updating the `CreateArticleForm` to use this function and send the correct author object.

Second, it fixes a React hydration error that occurred on page load. The Zustand auth store was being initialized directly from `localStorage`, causing a mismatch between the server-rendered and client-rendered HTML. This is resolved by:
- Modifying the `useAuthStore` to always initialize with a default, server-friendly state.
- Relying on the existing client-side `initializeAuthState` function to correctly hydrate the store after the initial render.