### PR TITLE
This commit addresses a persistent hydration error on the `/create-ar…

### DIFF
--- a/src/app/admin/create-article/page.tsx
+++ b/src/app/admin/create-article/page.tsx
@@ -1,14 +1,33 @@
 // src/app/admin/create-article/page.tsx
-import CreateArticleForm from '@/components/admin/CreateArticleForm';
-import { Metadata } from 'next';
+"use client";
 
-// Metadata for this specific page
-export const metadata: Metadata = {
-  title: 'Create Article | DTIS',
-  description: 'Admin portal to create and publish new articles for the DTIS news section.',
-};
+import CreateArticleForm from '@/components/admin/CreateArticleForm';
+import { useAdminRedirect } from '@/hooks/useAdminRedirect';
+import React from 'react';
 
 const CreateArticlePage = () => {
+  const { userIsAdmin, isLoading: isAuthLoading } = useAdminRedirect();
+
+  // Render a loading state while authentication is being checked
+  if (isAuthLoading) {
+    return (
+      <div className="flex justify-center items-center py-10">
+        <svg className="animate-spin h-8 w-8 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <span className="ml-3 text-lg text-gray-600">Loading admin tools...</span>
+      </div>
+    );
+  }
+
+  // The hook handles the redirect if the user is not an admin.
+  // We render null here, and the redirect happens in the hook.
+  if (!userIsAdmin) {
+    return null;
+  }
+
+  // If user is an admin, render the form
   return (
     <div className="py-8">
       <CreateArticleForm />

--- a/src/components/admin/CreateArticleForm.tsx
+++ b/src/components/admin/CreateArticleForm.tsx
@@ -7,31 +7,26 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
-import { useAdminRedirect } from '@/hooks/useAdminRedirect';
 import { useRouter } from 'next/navigation';
 import { createArticle } from '@/api/articles';
 import Link from 'next/link';
-import dynamic from 'next/dynamic'; // Import dynamic from Next.js
+import dynamic from 'next/dynamic';
 import 'react-quill/dist/quill.snow.css';
 import { useAuthStore } from '@/store/authStore';
 
-// Dynamically import ReactQuill, but disable SSR
 const ReactQuillNoSSR = dynamic(
   () => import('react-quill'),
   { ssr: false }
 );
 
-// Define the Zod schema for validation
 const articleSchema = z.object({
   title: z.string().min(5, 'Title must be at least 5 characters').max(100, 'Title cannot exceed 100 characters'),
   imageUrl: z.string().url('Must be a valid URL').optional().or(z.literal('')),
 });
 
-// Infer the type from the schema
 type ArticleFormInputs = z.infer<typeof articleSchema>;
 
 const CreateArticleForm: React.FC = () => {
-  const { userIsAdmin, isLoading: isAuthLoading } = useAdminRedirect();
   const { user } = useAuthStore();
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -81,24 +76,6 @@ const CreateArticleForm: React.FC = () => {
       setLoading(false);
     }
   };
-
-  // Render a loading state while authentication is being checked
-  if (isAuthLoading) {
-    return (
-      <div className="flex justify-center items-center py-10">
-        <svg className="animate-spin h-8 w-8 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-        </svg>
-        <span className="ml-3 text-lg text-gray-600">Loading admin tools...</span>
-      </div>
-    );
-  }
-
-  // The hook handles the redirect if the user is not an admin.
-  if (!userIsAdmin) {
-    return null;
-  }
 
   return (
     <div className="max-w-3xl mx-auto bg-white p-8 rounded-xl shadow-lg mt-8 mb-8">


### PR DESCRIPTION
…ticle` page by refactoring the component structure to better handle client-side authentication checks.

- The page component (`/admin/create-article/page.tsx`) is converted to a Client Component.
- All logic for checking authentication status, showing a loading state, and handling redirects is moved into this page component.
- The `CreateArticleForm` component is simplified into a presentational component, with the complex auth and loading logic removed.

This separation of concerns makes the rendering logic more robust and less prone to server-client mismatches, resolving the hydration error.