### PR TITLE
fix: Correct autocomplete dropdown behavior

### DIFF
--- a/src/components/reports/ReportThreatForm.tsx
+++ b/src/components/reports/ReportThreatForm.tsx
@@ -154,7 +154,7 @@ const ReportThreatForm: React.FC = () => {
         </div>
       )}
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-        <div className="relative">
+        <div className="relative" ref={dropdownRef}>
           <Input
             id="instrument"
             label="Threat Instrument (e.g., domain, phone number, email)"
@@ -165,7 +165,7 @@ const ReportThreatForm: React.FC = () => {
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInstrumentValue(e.target.value)}
           />
           {isDropdownVisible && suggestions.length > 0 && (
-            <div ref={dropdownRef} className="absolute z-10 w-full bg-white border border-gray-300 rounded-md shadow-lg mt-1">
+            <div className="absolute z-10 w-full bg-white border border-gray-300 rounded-md shadow-lg mt-1">
               <ul>
                 {suggestions.map((suggestion) => (
                   <li


### PR DESCRIPTION
This commit fixes a bug where the autocomplete dropdown would close immediately after opening. The issue was caused by the click-outside handler incorrectly identifying interactions with the input field as clicks outside the component.

- The `ref` has been moved to the parent container that wraps both the input and the dropdown to ensure that clicks within the component are handled correctly.