### PR TITLE
feat: Implement report management for admins and users

### DIFF
--- a/src/api/reports.ts
+++ b/src/api/reports.ts
@@ -55,3 +55,28 @@ export const toggleReportVisibility = async (id: number) => {
   const response = await apiClient.patch(`/admin/reports/${id}/visibility`);
   return response.data;
 };
+
+// Interface for updating a report
+interface UpdateReportData {
+  instrument?: string;
+  type?: WatchlistCategory;
+  description?: string;
+}
+
+// User updates their own report
+export const updateReport = async (id: number, data: UpdateReportData): Promise<any> => {
+  const response = await apiClient.put(`/reports/${id}`, data);
+  return response.data;
+};
+
+// Admin updates a report
+export const updateReportByAdmin = async (id: number, data: UpdateReportData): Promise<any> => {
+  const response = await apiClient.put(`/reports/admin/${id}`, data);
+  return response.data;
+};
+
+// Admin deletes a report
+export const deleteReportByAdmin = async (id: number): Promise<any> => {
+  const response = await apiClient.delete(`/reports/admin/${id}`);
+  return response.data;
+};

--- a/src/app/api/admin/reports/[id]/route.ts
+++ b/src/app/api/admin/reports/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+// In-memory data store
+let reports = [
+  { id: 1, instrument: 'example.com', type: 'Phishing Website', description: 'A fake login page for a bank.', status: 'public', reviews: 5 },
+  { id: 2, instrument: 'scam@example.com', type: 'Scam Email', description: 'An email asking for money.', status: 'hidden', reviews: 2 },
+  { id: 3, instrument: '1-800-bad-guy', type: 'Fraudulent Phone Number', description: 'A fake tech support number.', status: 'public', reviews: 10 },
+  { id: 4, instrument: 'malware.com', type: 'Malware Distribution', description: 'A site that downloads a virus.', status: 'public', reviews: 1 },
+];
+
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
+  const { id } = params;
+  const body = await request.json();
+  const { instrument, type, description } = body;
+
+  const reportIndex = reports.findIndex(report => report.id === parseInt(id));
+
+  if (reportIndex === -1) {
+    return NextResponse.json({ message: 'Report not found' }, { status: 404 });
+  }
+
+  reports[reportIndex] = { ...reports[reportIndex], instrument, type, description };
+
+  return NextResponse.json(reports[reportIndex]);
+}
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const { id } = params;
+  const reportIndex = reports.findIndex(report => report.id === parseInt(id));
+
+  if (reportIndex === -1) {
+    return NextResponse.json({ message: 'Report not found' }, { status: 404 });
+  }
+
+  reports = reports.filter(report => report.id !== parseInt(id));
+
+  return NextResponse.json({ message: 'Report deleted successfully' });
+}

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { NextApiRequest } from 'next';
+
+// In-memory data store
+let reports = [
+  { id: 1, instrument: 'example.com', type: 'Phishing Website', description: 'A fake login page for a bank.', status: 'public', reviews: 5, userId: 'user1', createdAt: new Date() },
+  { id: 2, instrument: 'scam@example.com', type: 'Scam Email', description: 'An email asking for money.', status: 'hidden', reviews: 2, userId: 'user2', createdAt: new Date() },
+  { id: 3, instrument: '1-800-bad-guy', type: 'Fraudulent Phone Number', description: 'A fake tech support number.', status: 'public', reviews: 10, userId: 'user1', createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000) }, // 2 hours ago
+];
+
+// Mock user session
+const getUserId = (req: NextApiRequest) => {
+  // In a real app, you would get the user ID from the session or token
+  return 'user1';
+};
+
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
+  const { id } = params;
+  const body = await request.json();
+  const { instrument, type, description } = body;
+
+  // In a real app, you would get the user ID from the session or token
+  const userId = 'user1'; // Mocking user ID
+
+  const reportIndex = reports.findIndex(report => report.id === parseInt(id));
+
+  if (reportIndex === -1) {
+    return NextResponse.json({ message: 'Report not found' }, { status: 404 });
+  }
+
+  const report = reports[reportIndex];
+
+  if (report.userId !== userId) {
+    return NextResponse.json({ message: 'You are not authorized to edit this report' }, { status: 403 });
+  }
+
+  const now = new Date();
+  const reportDate = new Date(report.createdAt);
+  const hoursDifference = (now.getTime() - reportDate.getTime()) / (1000 * 60 * 60);
+
+  if (hoursDifference > 1) {
+    return NextResponse.json({ message: 'You can only edit your report within one hour of creation' }, { status: 403 });
+  }
+
+  reports[reportIndex] = { ...report, instrument, type, description };
+
+  return NextResponse.json(reports[reportIndex]);
+}

--- a/src/app/reports/[id]/edit/page.tsx
+++ b/src/app/reports/[id]/edit/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from 'react';
+import EditReportForm from '@/components/reports/EditReportForm';
+import { useQuery } from '@tanstack/react-query';
+import { getPublicReports } from '@/api/reports'; // This is not ideal, but we'll use it for now
+import { Report } from '@/types/auth';
+
+// In a real app, you would have a function to get a single report by ID
+const getReportById = async (id: string): Promise<Report | undefined> => {
+  const { reports } = await getPublicReports({ page: 1, limit: 100 }); // Fetch all reports and find the one with the matching ID
+  return reports.find((report) => report._id === id);
+};
+
+const EditReportPage = ({ params }: { params: { id: string } }) => {
+  const { id } = params;
+  const { data: report, isLoading, isError } = useQuery({
+    queryKey: ['report', id],
+    queryFn: () => getReportById(id),
+  });
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (isError || !report) {
+    return <div>Report not found</div>;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Edit Report</h1>
+      <EditReportForm report={report} />
+    </div>
+  );
+};
+
+export default EditReportPage;

--- a/src/components/reports/EditReportForm.tsx
+++ b/src/components/reports/EditReportForm.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React, { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateReport } from '@/api/reports';
+import { useRouter } from 'next/navigation';
+
+interface Report {
+  _id: string;
+  instrument: string;
+  type: string;
+  description: string;
+}
+
+interface EditReportFormProps {
+  report: Report;
+}
+
+const EditReportForm: React.FC<EditReportFormProps> = ({ report }) => {
+  const [instrument, setInstrument] = useState(report.instrument);
+  const [type, setType] = useState(report.type);
+  const [description, setDescription] = useState(report.description);
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const updateMutation = useMutation({
+    mutationFn: (updatedReport: { instrument: string; type: string; description: string }) =>
+      updateReport(parseInt(report._id), updatedReport),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reports'] });
+      router.push('/reports');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updateMutation.mutate({ instrument, type, description });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="instrument" className="block text-sm font-medium text-gray-700">
+          Instrument
+        </label>
+        <input
+          type="text"
+          id="instrument"
+          value={instrument}
+          onChange={(e) => setInstrument(e.target.value)}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+        />
+      </div>
+      <div>
+        <label htmlFor="type" className="block text-sm font-medium text-gray-700">
+          Type
+        </label>
+        <input
+          type="text"
+          id="type"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+        />
+      </div>
+      <div>
+        <label htmlFor="description" className="block text-sm font-medium text-gray-700">
+          Description
+        </label>
+        <textarea
+          id="description"
+          value={description}
+          onChange={(e) => setDescription(e.targe.value)}
+          rows={4}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+        />
+      </div>
+      <button
+        type="submit"
+        className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        disabled={updateMutation.isPending}
+      >
+        {updateMutation.isPending ? 'Updating...' : 'Update Report'}
+      </button>
+    </form>
+  );
+};
+
+export default EditReportForm;

--- a/src/components/reports/ReportsTable.tsx
+++ b/src/components/reports/ReportsTable.tsx
@@ -129,26 +129,46 @@ const ReportsTable: React.FC = () => {
               <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                 Reported
               </th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {reports.length ? (
-              reports.map((report: Report) => (
-                <tr key={report._id} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-blue-600 hover:underline cursor-pointer">
-                    <Link href={`/reports/${report._id}`}>{report.instrument}</Link>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {report.type}
-                  </td>
-                  <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
-                    {report.description}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    <ClientSideFormattedDate dateString={report.createdAt} />
-                  </td>
-                </tr>
-              ))
+              reports.map((report: Report) => {
+                // Mock user ID
+                const userId = 'user1';
+                const isOwner = report.reporterId === userId;
+                const now = new Date();
+                const reportDate = new Date(report.createdAt);
+                const hoursDifference = (now.getTime() - reportDate.getTime()) / (1000 * 60 * 60);
+                const canEdit = isOwner && hoursDifference <= 1;
+
+                return (
+                  <tr key={report._id} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-blue-600 hover:underline cursor-pointer">
+                      <Link href={`/reports/${report._id}`}>{report.instrument}</Link>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {report.type}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                      {report.description}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <ClientSideFormattedDate dateString={report.createdAt} />
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                      {canEdit && (
+                        <Link href={`/reports/${report._id}/edit`} className="text-indigo-600 hover:text-indigo-900">
+                          Edit
+                        </Link>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
             ) : (
               <tr>
                 <td colSpan={4} className="px-6 py-4 whitespace-nowrap text-center text-sm text-gray-500">


### PR DESCRIPTION
This commit introduces the following features:

- Admins can now edit and delete reports from the admin dashboard.
- Users can now edit their own reports within one hour of creation.

The following changes were made:

- Added API routes for updating and deleting reports by admins.
- Added an API route for users to update their own reports.
- Updated the API client to include functions for the new routes.
- Enhanced the admin dashboard with "Edit" and "Delete" buttons for reports.
- Added a new page for users to edit their reports.
- Added an "Edit" button to the reports table for eligible reports.