### PR TITLE
feat: Enhance report editing and fix admin filter

### DIFF
--- a/src/api/reports.ts
+++ b/src/api/reports.ts
@@ -61,22 +61,20 @@ interface UpdateReportData {
   instrument?: string;
   type?: WatchlistCategory;
   description?: string;
+  aliases?: string[];
 }
 
 // User updates their own report
-export const updateReport = async (id: number, data: UpdateReportData): Promise<any> => {
-  const response = await apiClient.put(`/reports/${id}`, data);
-  return response.data;
+export const updateReport = async (id: number, data: UpdateReportData): Promise<void> => {
+  await apiClient.put(`/reports/${id}`, data);
 };
 
 // Admin updates a report
-export const updateReportByAdmin = async (id: number, data: UpdateReportData): Promise<any> => {
-  const response = await apiClient.put(`/reports/admin/${id}`, data);
-  return response.data;
+export const updateReportByAdmin = async (id: number, data: UpdateReportData): Promise<void> => {
+  await apiClient.put(`/reports/admin/${id}`, data);
 };
 
 // Admin deletes a report
-export const deleteReportByAdmin = async (id: number): Promise<any> => {
-  const response = await apiClient.delete(`/reports/admin/${id}`);
-  return response.data;
+export const deleteReportByAdmin = async (id: number): Promise<void> => {
+  await apiClient.delete(`/reports/admin/${id}`);
 };

--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -1,20 +1,28 @@
 import { NextResponse } from 'next/server';
 
 const reports = [
-  { id: 1, instrument: 'example.com', type: 'Phishing Website', description: 'A fake login page for a bank.', status: 'public', reviews: 5 },
-  { id: 2, instrument: 'scam@example.com', type: 'Scam Email', description: 'An email asking for money.', status: 'hidden', reviews: 2 },
-  { id: 3, instrument: '1-800-bad-guy', type: 'Fraudulent Phone Number', description: 'A fake tech support number.', status: 'public', reviews: 10 },
-  { id: 4, instrument: 'malware.com', type: 'Malware Distribution', description: 'A site that downloads a virus.', status: 'public', reviews: 1 },
+  { id: 1, instrument: 'example.com', type: 'Phishing Website', description: 'A fake login page for a bank.', status: 'public', reviews: 5, aliases: ['ex.com', 'example.org'] },
+  { id: 2, instrument: 'scam@example.com', type: 'Scam Email', description: 'An email asking for money.', status: 'hidden', reviews: 2, aliases: [] },
+  { id: 3, instrument: '1-800-bad-guy', type: 'Fraudulent Phone Number', description: 'A fake tech support number.', status: 'public', reviews: 10, aliases: ['1-800-bad-guys'] },
+  { id: 4, instrument: 'malware.com', type: 'Malware Distribution', description: 'A site that downloads a virus.', status: 'public', reviews: 1, aliases: [] },
 ];
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const category = searchParams.get('category');
+  const type = searchParams.get('type');
+  const instrument = searchParams.get('instrument');
 
-  if (category) {
-    const filteredReports = reports.filter((report) => report.type === category);
-    return NextResponse.json(filteredReports);
+  let filteredReports = reports;
+
+  if (type) {
+    filteredReports = filteredReports.filter((report) => report.type === type);
   }
 
-  return NextResponse.json(reports);
+  if (instrument) {
+    filteredReports = filteredReports.filter((report) =>
+      report.instrument.toLowerCase().includes(instrument.toLowerCase())
+    );
+  }
+
+  return NextResponse.json(filteredReports);
 }

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { NextApiRequest } from 'next';
 
 // In-memory data store
-let reports = [
+const reports = [
   { id: 1, instrument: 'example.com', type: 'Phishing Website', description: 'A fake login page for a bank.', status: 'public', reviews: 5, userId: 'user1', createdAt: new Date() },
   { id: 2, instrument: 'scam@example.com', type: 'Scam Email', description: 'An email asking for money.', status: 'hidden', reviews: 2, userId: 'user2', createdAt: new Date() },
   { id: 3, instrument: '1-800-bad-guy', type: 'Fraudulent Phone Number', description: 'A fake tech support number.', status: 'public', reviews: 10, userId: 'user1', createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000) }, // 2 hours ago
@@ -17,7 +17,7 @@ const getUserId = (req: NextApiRequest) => {
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
   const { id } = params;
   const body = await request.json();
-  const { instrument, type, description } = body;
+  const { instrument, type, description, aliases } = body;
 
   // In a real app, you would get the user ID from the session or token
   const userId = 'user1'; // Mocking user ID
@@ -42,7 +42,7 @@ export async function PUT(request: Request, { params }: { params: { id: string }
     return NextResponse.json({ message: 'You can only edit your report within one hour of creation' }, { status: 403 });
   }
 
-  reports[reportIndex] = { ...report, instrument, type, description };
+  reports[reportIndex] = { ...report, instrument, type, description, aliases };
 
   return NextResponse.json(reports[reportIndex]);
 }


### PR DESCRIPTION
This commit addresses two issues:

1.  The report editing functionality has been enhanced to allow editing of the description and aliases, in addition to the instrument and category. The category is now a dropdown populated with the available report types.

2.  The filter by instrument functionality on the admin dashboard has been fixed. The backend now correctly filters reports by instrument and type.