### PR TITLE
fix(frontend): Align report API consumption with backend

### DIFF
--- a/src/api/reports.ts
+++ b/src/api/reports.ts
@@ -6,7 +6,8 @@ import { GetReportsResponse, WatchlistCategory } from '@/types/auth'; // Using a
 interface GetReportsParams {
   page?: number;
   limit?: number;
-  search?: string;
+  instrument?: string;
+  type?: string;
 }
 
 // Get all public reports
@@ -56,21 +57,31 @@ export const toggleReportVisibility = async (id: number) => {
   return response.data;
 };
 
-// Interface for updating a report
-interface UpdateReportData {
-  instrument?: string;
-  type?: WatchlistCategory;
+// Interface for updating a report by a user
+interface UserUpdateReportData {
   description?: string;
   aliases?: string[];
 }
 
+// Interface for updating a report by an admin
+interface AdminUpdateReportData {
+  instrument?: string;
+  type?: WatchlistCategory;
+  description?: string;
+  aliases?: string[];
+  riskLevel?: 'low' | 'medium' | 'high';
+  isPublic?: boolean;
+  forcePublic?: boolean;
+  verificationStatus?: 'unverified' | 'verified';
+}
+
 // User updates their own report
-export const updateReport = async (id: number, data: UpdateReportData): Promise<void> => {
+export const updateReport = async (id: string, data: UserUpdateReportData): Promise<void> => {
   await apiClient.put(`/reports/${id}`, data);
 };
 
 // Admin updates a report
-export const updateReportByAdmin = async (id: number, data: UpdateReportData): Promise<void> => {
+export const updateReportByAdmin = async (id: number, data: AdminUpdateReportData): Promise<void> => {
   await apiClient.put(`/reports/admin/${id}`, data);
 };
 

--- a/src/components/reports/EditReportForm.tsx
+++ b/src/components/reports/EditReportForm.tsx
@@ -24,8 +24,8 @@ const EditReportForm: React.FC<EditReportFormProps> = ({ report }) => {
   });
 
   const updateMutation = useMutation({
-    mutationFn: (updatedReport: { instrument: string; type: WatchlistCategory; description: string; aliases?: string[] }) =>
-      updateReport(parseInt(report._id), updatedReport),
+    mutationFn: (updatedReport: { description: string; aliases?: string[] }) =>
+      updateReport(report._id, updatedReport),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['reports'] });
       router.push('/reports');
@@ -35,7 +35,7 @@ const EditReportForm: React.FC<EditReportFormProps> = ({ report }) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const aliasesArray = aliases.split(',').map(alias => alias.trim()).filter(alias => alias);
-    updateMutation.mutate({ instrument, type, description, aliases: aliasesArray });
+    updateMutation.mutate({ description, aliases: aliasesArray });
   };
 
   return (
@@ -48,8 +48,8 @@ const EditReportForm: React.FC<EditReportFormProps> = ({ report }) => {
           type="text"
           id="instrument"
           value={instrument}
-          onChange={(e) => setInstrument(e.target.value)}
-          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          readOnly
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm bg-gray-100 sm:text-sm"
         />
       </div>
       <div>
@@ -59,13 +59,10 @@ const EditReportForm: React.FC<EditReportFormProps> = ({ report }) => {
         <select
           id="type"
           value={type}
-          onChange={(e) => setType(e.target.value as WatchlistCategory)}
-          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-          disabled={typesLoading}
+          disabled
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm bg-gray-100 sm:text-sm"
         >
-          {reportTypes?.map(reportType => (
-            <option key={reportType} value={reportType}>{reportType}</option>
-          ))}
+          <option value={type}>{type}</option>
         </select>
       </div>
       <div>


### PR DESCRIPTION
This commit addresses several discrepancies between the frontend and the backend API for the reporting feature.

- **Reports Table (`ReportsTable.tsx`)**:
  - The public reports page now uses server-side filtering and searching by passing the correct `instrument` and `type` parameters to the API.
  - This removes the inefficient client-side filtering logic.
  - The component now fetches and displays the total and verified threat statistics from the `GET /api/reports/stats/total` endpoint.

- **Admin Dashboard (`AdminDashboard.tsx`)**:
  - The admin edit modal has been updated to include all fields supported by the backend (`riskLevel`, `verificationStatus`, `isPublic`, `forcePublic`).
  - The `AdminUpdateReportData` type in the API layer was updated to support these new fields.

- **Edit Report Form (`EditReportForm.tsx`)**:
  - Fixed a bug where the report `_id` was incorrectly parsed as an integer. It is now correctly passed as a string.
  - The `instrument` and `type` fields are now correctly marked as read-only for non-admin users to align with backend capabilities.